### PR TITLE
Changed to use language-tool-python instead of language_check

### DIFF
--- a/pycontractions/contractions.py
+++ b/pycontractions/contractions.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import gensim.downloader as api
 from gensim.models import KeyedVectors
 from itertools import combinations_with_replacement, permutations
-import language_check
+import language_tool_python
 import os
 import sys
 import re
@@ -327,7 +327,7 @@ class Contractions(object):
             raise AttributeError("No model given")
 
         try:
-            self.lc_tool = language_check.LanguageTool(self.lang_code)
+            self.lc_tool = language_tool_python.LanguageTool(self.lang_code)
         except:
             print("Error initializing LanguageTool")
             raise

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     long_description=open("README.rst").read(),
-    install_requires=["gensim>=2.0", "language_check>=1.0", "pyemd>=0.4.4"],
+    install_requires=["gensim>=2.0", "language-tool-python>=2.5.3", "pyemd>=0.4.4"],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
Due to the issue of installing `language_check` I changed this package to the `language-tool-python` package, which seems to work better. This PR will hopefully fix #17 